### PR TITLE
Replace punycode dep with URL hack

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Punycode = require('punycode');
+const Url = require('url');
 
 const Abnf = require('./abnf');
 const Tlds = require('./tlds');
@@ -44,7 +44,7 @@ module.exports = {
                 }
 
                 const normalized = domain.normalize('NFC');
-                domain = Punycode.toASCII(normalized);
+                domain = internals.punycodeDomain(normalized);
             }
 
             return internals.domain(domain, options);
@@ -74,7 +74,7 @@ internals.email = function (email, options = {}) {
         }
 
         const normalized = email.normalize('NFC');
-        email = Punycode.toASCII(normalized);
+        email = internals.punycode(normalized);
     }
 
     // Basic structure
@@ -245,4 +245,24 @@ internals.tlds = function (options) {
 internals.error = function (reason) {
 
     return { error: reason };
+};
+
+
+internals.punycodeDomain = function (domain) {
+
+    // This re-uses the URL http scheme punycode encoder
+
+    try {
+        return new Url.URL('http://' + domain).host;
+    }
+    catch (err) {
+        return domain;
+    }
+};
+
+
+internals.punycode = function (normalized) {
+
+    const indexOfAt = normalized.lastIndexOf('@');
+    return normalized.slice(0, indexOfAt + 1) + internals.punycodeDomain(normalized.slice(indexOfAt + 1));
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {},
   "devDependencies": {
     "@hapi/code": "6.x.x",
-    "@hapi/lab": "20.x.x"
+    "@hapi/lab": "20.x.x",
+    "punycode": "2.x.x"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/test/index.js
+++ b/test/index.js
@@ -305,7 +305,7 @@ describe('email', () => {
                 ['\"\\\ud800\"@invalid', false],
                 ['(\ud800)thing@invalid', false],
                 ['\"\\\ud800\"@invalid', false],
-                ['test@\ud800\udfffñoñó郵件ñoñó郵件.郵件ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.noñó郵件.商務', true, { tlds: { allow: new Set([Punycode.toASCII('商務')]) } }],
+                ['test@\ud800\udfffñoñó郵件ñoñó郵件.郵件ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.noñó郵件.商務', false, { tlds: { allow: new Set([Punycode.toASCII('商務')]) } }],
                 ['test@\ud800\udfffñoñó郵件ñoñó郵件.郵件ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.noñó郵件ñoñó郵.商務', false, { tlds: { allow: new Set([Punycode.toASCII('商務')]) } }],
                 ['test@\ud800\udfffñoñó郵件ñoñó郵件.郵件ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.ñoñó郵件ñoñó郵件.oñó郵件ñoñó郵件ñoñó郵件.商務', false, { tlds: { allow: new Set([Punycode.toASCII('商務')]) } }],
                 ['test@ñoñoñó郵件\ud83d\ude06ñoñ.oñó郵件\uc138ñoñ.oñó郵件\u0644\u4eec\u010dñoñoñó郵件\u05dcño.ñoñó郵件\u092f\u672cñoñoñó郵件\uc138añoñ.oñó郵件\ud83d\ude06bc\uc138郵\ud83d\ude06ño.ñoñó郵件ñoñoñó郵件\ud83d\ude06ñoñoñó郵件\uc138ñoñ.oñó郵件\u0644\u4eecñoñoñó.郵件\ud83d\ude06ñoñoñó郵件郵\uc138ñoñoñó郵件\u0644\u4eecñoñoñó郵件.\ud83d\ude06ñoñoñó郵件郵\uc138\u0644\u4eec.郵件\ud83d\ude06ñoñoñó郵.件郵\uc138\u4eec\ud83d\ude06ñoñoñó件郵\uc138ñoñoñó郵件', false, { tlds: { allow: new Set([Punycode.toASCII('商務')]) } }],
@@ -320,7 +320,8 @@ describe('email', () => {
                 ['apple-touch-icon-60x60@2x.png', false],
                 ['shouldbe@XN--UNUP4Y', true, { minDomainSegments: 1 }],
                 ['shouldbe@xn--unup4y', true, { minDomainSegments: 1 }],
-                ['shouldbe@\u6e38\u620f', true, { minDomainSegments: 1 }]
+                ['shouldbe@\u6e38\u620f', true, { minDomainSegments: 1 }],
+                ['æøå', false]
             ];
 
             for (let i = 0; i < tests.length; ++i) {


### PR DESCRIPTION
This patch replaces the `punycode` dependency with a clever hack that uses the WHATWG URL parsing logic to apply punycode decoding to the domain.

I only changed it for the implementation itself, and not the test logic.

I also didn't remove it as a dependency, as it was missing, and only incidentally available in the `node_modules` from the eslint dependency.