### PR TITLE
feat: add underscore support

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,6 +7,7 @@ Analyzes a string to verify it is a valid domain name where:
 -   `domain` - the domain name string being verified.
 -   `options` - optional settings:
     -   `allowUnicode` - if `false`, Unicode characters are not allowed in domain names. Defaults to `true`.
+    -   `allowUnderscore` - if `false`, underscore (`_`) characters will not be allowed in the domain name. Defaults to `false`.
     -   `minDomainSegments` - the minimum number of domain segments (e.g. `x.y.z` has 3 segments) required. Defaults to `2`.
     -   `tlds` - options to validate the top-level-domain segment (e.g. `com` in `example.com`) where:
         -   `deny` - a `Set` with strings matching forbidden TLD values (all non-matching values are allowed).
@@ -30,6 +31,7 @@ Analyzes a string to verify it is a valid email address where:
 -   `email` - the email address string being verified.
 -   `options` - optional settings:
     -   `allowUnicode` - if `false`, Unicode characters are not allowed in the email address local and domain parts. Defaults to `true`.
+    -   `allowUnderscore` - if `false`, underscore (`_`) characters will not be allowed in the domain name. Defaults to `false`.
     -   `ignoreLength` - if `true`, the standards email maximum length limit is ignored. Defaults to `true`.
     -   `minDomainSegments` - the minimum number of domain segments (e.g. `x.y.z` has 3 segments) required in the domain part. Defaults to `2`.
     -   `tlds` - options to validate the top-level-domain segment (e.g. `com` in `example.com`) where:

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -7,6 +7,7 @@ const NON_ASCII_RX = /[^\x00-\x7f]/;
 const DOMAIN_CONTROL_RX = /[\x00-\x20@\:\/\\#!\$&\'\(\)\*\+,;=\?]/; // Control + space + separators
 const TLD_SEGMENT_RX = /^[a-zA-Z](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?$/;
 const DOMAIN_SEGMENT_RX = /^[a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?$/;
+const DOMAIN_UNDERSCORE_SEGMENT_RX = /^[a-zA-Z0-9_](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?$/;
 const URL_IMPL = Url.URL || URL; // $lab:coverage:ignore$
 
 interface TldsAllow {
@@ -28,6 +29,13 @@ export interface DomainOptions {
      * @default true
      */
     readonly allowUnicode?: boolean;
+
+    /**
+     * Determines whether underscore (_) characters are allowed.
+     *
+     * @default false
+     */
+    readonly allowUnderscore?: boolean;
 
     /**
      * The maximum number of domain segments (e.g. `x.y.z` has 3 segments) allowed.
@@ -151,8 +159,14 @@ export function analyzeDomain(domain: string, options: DomainOptions = {}): Anal
         }
 
         if (i < segments.length - 1) {
-            if (!DOMAIN_SEGMENT_RX.test(segment)) {
-                return errorCode('DOMAIN_INVALID_CHARS');
+            if (options.allowUnderscore) {
+                if (!DOMAIN_UNDERSCORE_SEGMENT_RX.test(segment)) {
+                    return errorCode('DOMAIN_INVALID_CHARS');
+                }
+            } else {
+                if (!DOMAIN_SEGMENT_RX.test(segment)) {
+                    return errorCode('DOMAIN_INVALID_CHARS');
+                }
             }
         } else {
             if (!TLD_SEGMENT_RX.test(segment)) {

--- a/test/domain.ts
+++ b/test/domain.ts
@@ -108,7 +108,8 @@ describe('domain', () => {
                 ['_abc.example.com', true, { allowUnderscore: true }],
                 ['_abc.example.com', false],
                 ['_example.com', true, { allowUnderscore: true }],
-                ['_example.com', false]
+                ['_example.com', false],
+                ['_abc.{example}.com', false, { allowUnderscore: true }]
             ];
 
             for (let i = 0; i < tests.length; ++i) {

--- a/test/domain.ts
+++ b/test/domain.ts
@@ -101,7 +101,14 @@ describe('domain', () => {
                 ['example.com%2e', false],
                 ['example.com.', false],
                 ['example.com.', true, { allowFullyQualified: true }],
-                ['example.com', true, { allowFullyQualified: true }]
+                ['example.com', true, { allowFullyQualified: true }],
+                ['_acme-challenge.example.com', false],
+                ['_acme-challenge.example.com', true, { allowUnderscore: true }],
+                ['_acme-challenge.example.com', false, { allowUnderscore: false }],
+                ['_abc.example.com', true, { allowUnderscore: true }],
+                ['_abc.example.com', false],
+                ['_example.com', true, { allowUnderscore: true }],
+                ['_example.com', false]
             ];
 
             for (let i = 0; i < tests.length; ++i) {


### PR DESCRIPTION
Adds support for underscore character (`_`) in domain names. While registers don't allow it for top-level domains, it should be supported based on RFC specification, and is widely used for subdomanis (e.g. letsencrypt dns). To not break backwards compatibility - I've set it to `false`, by default.

https://stackoverflow.com/a/2183140/2225918

PS I'm aware of the test coverage issue. I can't manage to get it right.