### PR TITLE
test: use modern supported punycode

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-prettier": "^4.2.1",
         "prettier": "^2.8.4",
+        "punycode": "^2.3.1",
         "typescript": "4.9.x"
     },
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-prettier": "^4.2.1",
         "prettier": "^2.8.4",
-        "punycode": "^2.3.1",
+        "punycode.js": "^2.3.1",
         "typescript": "4.9.x"
     },
     "scripts": {

--- a/test/domain.ts
+++ b/test/domain.ts
@@ -1,4 +1,4 @@
-import * as Punycode from 'punycode';
+import * as Punycode from 'punycode/';
 import { expect } from '@hapi/code';
 import * as Lab from '@hapi/lab';
 

--- a/test/domain.ts
+++ b/test/domain.ts
@@ -1,4 +1,4 @@
-import * as Punycode from 'punycode/';
+import * as Punycode from 'punycode.js';
 import { expect } from '@hapi/code';
 import * as Lab from '@hapi/lab';
 

--- a/test/email.ts
+++ b/test/email.ts
@@ -1,4 +1,4 @@
-import * as Punycode from 'punycode';
+import * as Punycode from 'punycode/';
 import { expect } from '@hapi/code';
 import * as Lab from '@hapi/lab';
 

--- a/test/email.ts
+++ b/test/email.ts
@@ -1,4 +1,4 @@
-import * as Punycode from 'punycode/';
+import * as Punycode from 'punycode.js';
 import { expect } from '@hapi/code';
 import * as Lab from '@hapi/lab';
 


### PR DESCRIPTION
Perhaps you've noticed the error messages in the test output?

```
(node:76084) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

The 'included' punycode in node stopped getting updated in node 7, so it's better to use the [punycode NPM module](https://www.npmjs.com/package/punycode). This adds it as a devDep and updates the import syntax as described in the README.